### PR TITLE
Add CartItem struct for handling items that are in a user's cart.

### DIFF
--- a/lib/catalog_api.ex
+++ b/lib/catalog_api.ex
@@ -4,6 +4,7 @@ defmodule CatalogApi do
   """
 
   alias CatalogApi.Address
+  alias CatalogApi.CartItem
   alias CatalogApi.Coercion
   alias CatalogApi.Error
   alias CatalogApi.Fault
@@ -245,7 +246,8 @@ defmodule CatalogApi do
   @doc """
   Returns the contents of the specified user's shopping cart.
 
-  The return contains the list of items in the cart.
+  The return contains the list of items in the cart casted as
+  `CatalogApi.CartItem{}` structs.
 
   The return also returns a map under the :status key which contains some
   information about the status of the cart. The keys contained in this map are
@@ -272,10 +274,9 @@ defmodule CatalogApi do
     with {:ok, response} <- HTTPoison.get(url),
          :ok <- Error.validate_response_status(response),
          {:ok, json} <- parse_json(response.body),
-         {:ok, items} <- Item.extract_items_from_json(json),
+         {:ok, items} <- CartItem.extract_items_from_json(json),
          {:ok, cart_status} <- extract_cart_status(json) do
       # TODO: Also extract cart's address information and return it
-      # TODO: Ensure item is casted as a CartItem
       {:ok, %{items: items, status: cart_status}}
     end
   end

--- a/lib/catalog_api/cart_item.ex
+++ b/lib/catalog_api/cart_item.ex
@@ -1,0 +1,70 @@
+defmodule CatalogApi.CartItem do
+  @moduledoc """
+  Defines the CatalogApi.CartItem struct and functions which are responsible for
+  parsing items in a user's cart from CatalogApi responses.
+  """
+
+  alias CatalogApi.Coercion
+  alias CatalogApi.CartItem
+
+  defstruct cart_price: nil,
+            catalog_item_id: nil,
+            catalog_points: nil,
+            catalog_price: nil,
+            currency: nil,
+            error: nil,
+            image_uri: nil,
+            is_available: nil,
+            is_valid: nil,
+            name: nil,
+            points: nil,
+            quantity: nil,
+            retail_price: nil,
+            shipping_estimate: nil
+
+  @type t :: %CatalogApi.CartItem{}
+
+  @valid_fields ~w(cart_price catalog_item_id catalog_points catalog_price
+    currency error image_uri is_available is_valid name points quantity 
+    retail_price shipping_estimate)
+
+  @boolean_fields ~w(is_available is_valid)
+
+  @doc """
+  Converts JSON representing an item in a user's cart and returns a
+  %CatalogApi.CartItem{} struct.
+  """
+  @spec cast(map()) :: t
+  def cast(item_json) when is_map(item_json) do
+    item_json
+    |> filter_unknown_properties # To avoid dynamically creating atoms
+    |> Coercion.integer_fields_to_boolean(@boolean_fields)
+    |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
+    |> Enum.into(%{})
+    |> to_struct
+  end
+
+  @doc """
+  Extracts %CatalogApi.CartItem{} struct(s) from a raw parsed json response.
+
+  If the parsed json response is not handled, returns an error tuple of the
+  format `{:error, :unparseable_catalog_api_items}`.
+  """
+  @spec extract_items_from_json(map()) ::
+    {:ok, list(t)}
+    | {:error, :unparseable_catalog_api_items}
+  def extract_items_from_json(
+    %{"cart_view_response" =>
+      %{"cart_view_result" =>
+        %{"items" =>
+          %{"CartItem" => items}}}}) when is_list(items) do
+    {:ok, Enum.map(items, fn item -> cast(item) end)}
+  end
+  def extract_items_from_json(_), do: {:error, :unparseable_catalog_api_items}
+
+  defp to_struct(map), do: struct(CartItem, map)
+
+  defp filter_unknown_properties(map) do
+    Enum.filter(map, fn {k, _v} -> k in @valid_fields end)
+  end
+end

--- a/lib/catalog_api/item.ex
+++ b/lib/catalog_api/item.ex
@@ -7,8 +7,6 @@ defmodule CatalogApi.Item do
   alias CatalogApi.Coercion
   alias CatalogApi.Item
 
-  #TODO: Separate item struct for item in cart, as there are additional fields.
-
   defstruct brand: nil,
             catalog_item_id: nil,
             catalog_price: nil,

--- a/lib/catalog_api/item.ex
+++ b/lib/catalog_api/item.ex
@@ -57,14 +57,6 @@ defmodule CatalogApi.Item do
           %{"CatalogItem" => items}}}}) when is_list(items) do
     {:ok, Enum.map(items, fn item -> cast(item) end)}
   end
-
-  def extract_items_from_json(
-    %{"cart_view_response" =>
-      %{"cart_view_result" =>
-        %{"items" =>
-          %{"CartItem" => items}}}}) when is_list(items) do
-    {:ok, Enum.map(items, fn item -> cast(item) end)}
-  end
   def extract_items_from_json(_), do: {:error, :unparseable_catalog_api_items}
 
   defp to_struct(map), do: struct(Item, map)

--- a/test/catalog_api/cart_item_test.exs
+++ b/test/catalog_api/cart_item_test.exs
@@ -1,0 +1,53 @@
+defmodule CatalogApi.CartItemTest do
+  use ExUnit.Case
+  doctest CatalogApi.CartItem
+  alias CatalogApi.CartItem
+
+  @base_item_json %{"cart_price" => "318.24",
+    "catalog_item_id" => 4439324,
+    "catalog_points" => 6365,
+    "catalog_price" => "318.24",
+    "currency" => "USD",
+    "error" => "",
+    "image_uri" => "image_url.com",
+    "is_available" => 1,
+    "is_valid" => 1,
+    "name" => "128GB iPod touch (Space Gray) (6th Generation)",
+    "points" => 6365,
+    "quantity" => 1,
+    "retail_price" => "279.99",
+    "shipping_estimate" => "0.00"}
+
+  describe "cast/1" do
+    test "produces an Item struct from json" do
+      assert %CartItem{} = CartItem.cast(@base_item_json)
+    end
+
+    test "coerces the has_options parameter to boolean" do
+      json = Map.put(@base_item_json, "is_available", 0)
+      assert %CartItem{is_available: false} = CartItem.cast(json)
+      json = Map.put(@base_item_json, "is_available", 1)
+      assert %CartItem{is_available: true} = CartItem.cast(json)
+
+      json = Map.put(@base_item_json, "is_valid", 0)
+      assert %CartItem{is_valid: false} = CartItem.cast(json)
+      json = Map.put(@base_item_json, "is_valid", 1)
+      assert %CartItem{is_valid: true} = CartItem.cast(json)
+    end
+  end
+
+  describe "extract_item_from_json/1" do
+    test "extracts an item from the cart_view response structure" do
+      json = %{"cart_view_response" => %{"cart_view_result" =>
+        %{"items" => %{"CartItem" => [@base_item_json, @base_item_json]}}}}
+      assert {:ok, [%CartItem{}, %CartItem{}]} = CartItem.extract_items_from_json(json)
+    end
+
+    test "returns an error tuple if structure is not parseable" do
+      error = {:error, :unparseable_catalog_api_items}
+      assert ^error = CartItem.extract_items_from_json(nil)
+      assert ^error = CartItem.extract_items_from_json(%{})
+      assert ^error = CartItem.extract_items_from_json([])
+    end
+  end
+end

--- a/test/catalog_api_test.exs
+++ b/test/catalog_api_test.exs
@@ -4,6 +4,7 @@ defmodule CatalogApiTest do
 
   import Mock
 
+  alias CatalogApi.CartItem
   alias CatalogApi.Fault
   alias CatalogApi.Fixture
   alias CatalogApi.Item
@@ -147,7 +148,7 @@ defmodule CatalogApiTest do
         response = CatalogApi.cart_view(123, 1)
         assert {:ok, %{items: items, status: status}} = response
 
-        Enum.map(items, &(assert %Item{} = &1))
+        Enum.map(items, &(assert %CartItem{} = &1))
 
         assert status[:error] == ""
         assert status[:has_item_errors] == false
@@ -163,7 +164,7 @@ defmodule CatalogApiTest do
         response = CatalogApi.cart_view(123, 1)
         assert {:ok, %{items: items, status: status}} = response
 
-        Enum.map(items, &(assert %Item{} = &1))
+        Enum.map(items, &(assert %CartItem{} = &1))
 
         assert status[:error] == "The cart requires an address. "
         assert status[:has_item_errors] == false

--- a/test/catalog_api_test.exs
+++ b/test/catalog_api_test.exs
@@ -123,6 +123,9 @@ defmodule CatalogApiTest do
       end
     end
 
+    # TODO: Add a test for when add_item fails because the item does not exist
+    # This should have a custom return.
+
     test "returns an error tuple with a fault struct when CatalogApi responds with a fault" do
       with_mock HTTPoison, [get: fn(_url) -> {:ok, @fault_response} end] do
         response = CatalogApi.cart_add_item(123, 1, 456)


### PR DESCRIPTION
Adds `CatalogApi.CartItem{}` which represents an item returned by the CatalogApi cart methods. This struct contains different fields than the `CatalogApi.Item{}` struct although there was some overlap. It didn't make sense to cast to an `Item{}` struct for these methods because many fields would always be nil and many fields in the json would be lost.