### PR TITLE
Fix CatalogApi.cart_view error for empty carts

### DIFF
--- a/lib/catalog_api.ex
+++ b/lib/catalog_api.ex
@@ -285,12 +285,15 @@ defmodule CatalogApi do
   defp extract_cart_status( %{"cart_view_response" => %{"cart_view_result" => params}}) do
     boolean_fields = ~w(has_item_errors is_valid locked needs_address)
 
-    %{"error" => error, "has_item_errors" => has_item_errors, "is_valid" => is_valid,
-      "cart_version" => cart_version, "locked" => locked, "needs_address" => needs_address}
-      = params |> Coercion.integer_fields_to_boolean(boolean_fields, true)
+    case params |> Coercion.integer_fields_to_boolean(boolean_fields, true) do
+      %{"error" => error, "has_item_errors" => has_item_errors,
+        "is_valid" => is_valid, "cart_version" => cart_version,
+        "locked" => locked, "needs_address" => needs_address} ->
 
-    {:ok, %{error: error, has_item_errors: has_item_errors, is_valid: is_valid,
-      cart_version: cart_version, locked: locked, needs_address: needs_address}}
+        {:ok, %{error: error, has_item_errors: has_item_errors, is_valid: is_valid,
+          cart_version: cart_version, locked: locked, needs_address: needs_address}}
+      _ -> {:ok, :cart_status_unavailable}
+    end
   end
   defp extract_cart_status(_), do: {:error, :unparseable_response_cart_status}
 

--- a/lib/catalog_api.ex
+++ b/lib/catalog_api.ex
@@ -267,7 +267,7 @@ defmodule CatalogApi do
     order has not changed since the application's state has been updated.
   """
   @spec cart_view(integer(), integer()) ::
-    {:ok, %{items: list(Item.t), status: map()}} | {:error, atom()}
+    {:ok, %{items: list(Item.t), status: map() | :unavailable_cart_status}} | {:error, atom()}
   def cart_view(socket_id, external_user_id) do
     params = %{socket_id: socket_id, external_user_id: external_user_id}
     url = Url.url_for("cart_view", params)

--- a/lib/catalog_api/cart_item.ex
+++ b/lib/catalog_api/cart_item.ex
@@ -64,7 +64,6 @@ defmodule CatalogApi.CartItem do
     %{"cart_view_response" => %{"cart_view_result" => %{"items" => %{}}}}) do
     {:ok, []}
   end
-
   def extract_items_from_json(_), do: {:error, :unparseable_catalog_api_items}
 
   defp to_struct(map), do: struct(CartItem, map)

--- a/lib/catalog_api/cart_item.ex
+++ b/lib/catalog_api/cart_item.ex
@@ -60,6 +60,11 @@ defmodule CatalogApi.CartItem do
           %{"CartItem" => items}}}}) when is_list(items) do
     {:ok, Enum.map(items, fn item -> cast(item) end)}
   end
+  def extract_items_from_json(
+    %{"cart_view_response" => %{"cart_view_result" => %{"items" => %{}}}}) do
+    {:ok, []}
+  end
+
   def extract_items_from_json(_), do: {:error, :unparseable_catalog_api_items}
 
   defp to_struct(map), do: struct(CartItem, map)

--- a/lib/catalog_api/fixture.ex
+++ b/lib/catalog_api/fixture.ex
@@ -153,7 +153,7 @@ defmodule CatalogApi.Fixture do
     end
   end
 
-  @cart_view_empty_cart_success "{\"cart_view_response\": {\"cart_view_result\": {\"credentials\": {\"checksum\": \"cnYAPXNzagegGC/1TWUwQhRoZCU=\", \"method\": \"cart_view\", \"uuid\": \"55470cc3-bf7d-453d-824e-faeaa922bf5b\", \"datetime\": \"2018-03-05T05:04:58.425254+00:00\"}, \"items\": {}}}}"
+  @cart_view_empty_cart_success_json "{\"cart_view_response\": {\"cart_view_result\": {\"credentials\": {\"checksum\": \"cnYAPXNzagegGC/1TWUwQhRoZCU=\", \"method\": \"cart_view\", \"uuid\": \"55470cc3-bf7d-453d-824e-faeaa922bf5b\", \"datetime\": \"2018-03-05T05:04:58.425254+00:00\"}, \"items\": {}}}}"
 
   @doc """
   Returns a `%HTTPPoison.Response{}` struct with a 200 status code and a body

--- a/test/catalog_api_test.exs
+++ b/test/catalog_api_test.exs
@@ -178,7 +178,7 @@ defmodule CatalogApiTest do
     test "returns no items if successful response indicating an empty cart" do
       with_mock HTTPoison, [get: fn(_url) -> {:ok, Fixture.cart_view_empty_cart_success()} end] do
         response = CatalogApi.cart_view(123, 1)
-        assert {:ok, %{items: []}} = response
+        assert {:ok, %{items: [], status: :cart_status_unavailable}} = response
       end
     end
 


### PR DESCRIPTION
`CatalogApi.cart_view/2` was returning `{:error, :unparseable_catalog_api_items}` when CatalogApi responded with an empty cart because it did not have a matching clause for CatalogApi's response which did not contain the `"CartItem"` key.

We now return `{:ok, %{items: [], status: :unavailable_cart_status}}` for this case. CatalogApi does not respond with any status information for empty carts, so there is unfortunately no information that we can provide.