### PR TITLE
Add bad cart version handling

### DIFF
--- a/lib/catalog_api.ex
+++ b/lib/catalog_api.ex
@@ -338,6 +338,12 @@ defmodule CatalogApi do
     passed version matches the version of the current cart. This can be used to
     ensure that the state of the users cart in your application has not become
     stale before the order is placed.
+
+  If the `cart_order_place/3` is invoked with cart version which does not match
+  the current version of the cart, then an error tuple will be returned of the
+  format `{:error, :stale_cart_version}`. This can be useful to ensure that the
+  order being placed matches what the consuming application believes the current
+  state of the cart to be,
   """
   @spec cart_order_place(integer(), integer(), Keyword.t) ::
     {:ok, map()}

--- a/lib/catalog_api.ex
+++ b/lib/catalog_api.ex
@@ -339,6 +339,14 @@ defmodule CatalogApi do
     ensure that the state of the users cart in your application has not become
     stale before the order is placed.
   """
+  @spec cart_order_place(integer(), integer(), Keyword.t) ::
+    {:ok, map()}
+    | {:error, :cart_not_found}
+    | {:error, :no_shipping_address}
+    | {:error, :stale_cart_version}
+    | {:error, {:bad_status, integer()}}
+    | {:error, {:catalog_api_fault, Error.extracted_fault}}
+    | {:error, Poison.ParseError.t}
   def cart_order_place(socket_id, external_user_id, opts \\ []) do
     allowed = [:cart_version]
     {:ok, optional_params} = filter_optional_params([], opts, allowed)
@@ -358,6 +366,9 @@ defmodule CatalogApi do
       {:error, {:catalog_api_fault,
         %Fault{faultstring: "A shipping address must be added to the cart."}}} ->
         {:error, :no_shipping_address}
+      {:error, {:catalog_api_fault,
+        %Fault{faultstring: "The given cart version does not match the cart."}}} ->
+        {:error, :stale_cart_version}
       other -> other
     end
   end

--- a/lib/catalog_api/fixture.ex
+++ b/lib/catalog_api/fixture.ex
@@ -184,7 +184,7 @@ defmodule CatalogApi.Fixture do
     end
   end
 
-  @cart_order_place_bad_cart_version_json "{\"Fault\": {\"faultcode\": \"Client.APIError\", \"faultstring\": \"The given cart version does not match the cart.\", \"detail\": null}}"
+  @bad_cart_version_fault_json "{\"Fault\": {\"faultcode\": \"Client.APIError\", \"faultstring\": \"The given cart version does not match the cart.\", \"detail\": null}}"
 
   @doc """
   Returns a `%HttpPoison.Response{}` struct with a 400 status code and a body
@@ -193,10 +193,10 @@ defmodule CatalogApi.Fixture do
 
   Returns only the body text if passed an argument of false to `as_response`.
   """
-  def cart_order_place_bad_cart_version_json(as_response \\ true) do
+  def bad_cart_version_fault(as_response \\ true) do
     case as_response do
-      true -> @cart_order_place_bad_cart_version_json |> as_response(400)
-      false -> @cart_order_place_bad_cart_version_json
+      true -> @bad_cart_version_fault_json |> as_response(400)
+      false -> @bad_cart_version_fault_json
     end
   end
 

--- a/lib/catalog_api/fixture.ex
+++ b/lib/catalog_api/fixture.ex
@@ -184,6 +184,22 @@ defmodule CatalogApi.Fixture do
     end
   end
 
+  @cart_order_place_bad_cart_version_json "{\"Fault\": {\"faultcode\": \"Client.APIError\", \"faultstring\": \"The given cart version does not match the cart.\", \"detail\": null}}"
+
+  @doc """
+  Returns a `%HttpPoison.Response{}` struct with a 400 status code and a body
+  which contains an error response indicating that the supplied cart_version
+  parameter did not match the current version of the cart.
+
+  Returns only the body text if passed an argument of false to `as_response`.
+  """
+  def cart_order_place_bad_cart_version_json(as_response \\ true) do
+    case as_response do
+      true -> @cart_order_place_bad_cart_version_json |> as_response(400)
+      false -> @cart_order_place_bad_cart_version_json
+    end
+  end
+
   @spec as_response(String.t, integer()) :: Response.t
   defp as_response(body, status) do
       %HTTPoison.Response{

--- a/test/catalog_api_test.exs
+++ b/test/catalog_api_test.exs
@@ -205,6 +205,13 @@ defmodule CatalogApiTest do
       end
     end
 
+    test "returns error tuple if the cart_version does not match current version" do
+      with_mock HTTPoison, [get: fn(_url) -> {:ok, Fixture.bad_cart_version_fault()} end] do
+        response = CatalogApi.cart_order_place(1061, 1, cart_version: "abcdefg")
+        assert {:error, :stale_cart_version} = response
+      end
+    end
+
     test "returns an error tuple if the cart is not found" do
       body = "{\"Fault\": {\"faultcode\": \"Client.APIError\", \"faultstring\": \"Cart not found.\", \"detail\":null}}"
       catalog_response = %HTTPoison.Response{


### PR DESCRIPTION
Adds a possible return type of the `CatalogApi.cart_order_place/3` function of `{:error, :stale_cart_version}` which is returned in the event that the supplied cart_version parameter does not match the current cart version on CatalogAPI's end. This ensures that the state of the cart when placing the cart is not different from what the consuming application expects.