### PR TITLE
Add address to CatalogApi.cart_view

### DIFF
--- a/lib/catalog_api/address.ex
+++ b/lib/catalog_api/address.ex
@@ -41,6 +41,24 @@ defmodule CatalogApi.Address do
   @type t :: %Address{}
   @type invalid_address_error :: {:invalid_address, list({atom(), list(String.t)})}
 
+  @valid_fields ~w(first_name last_name address_1 address_2 address_3 city
+    state_province postal_code country email phone_number)
+
+  @spec cast(map()) :: t
+  def cast(address_json) when is_map(address_json) do
+    address_json
+    |> filter_unknown_properties # To avoid dynamically creating atoms
+    |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
+    |> Enum.into(%{})
+    |> to_struct!
+  end
+
+  defp filter_unknown_properties(map) do
+    Enum.filter(map, fn {k, _v} -> k in @valid_fields end)
+  end
+
+  defp to_struct!(map), do: struct(Address, map)
+
   @doc """
   Validates a map with string or atom keys that is intended to represent a
   CatalogApi address.

--- a/lib/catalog_api/address.ex
+++ b/lib/catalog_api/address.ex
@@ -59,6 +59,13 @@ defmodule CatalogApi.Address do
 
   defp to_struct!(map), do: struct(Address, map)
 
+  def extract_address_from_json(
+    %{"cart_view_response" =>
+      %{"cart_view_result" => maybe_address}}) do
+        {:ok, cast(maybe_address)}
+  end
+  def extract_address_from_json(_), do: {:error, :unparseable_catalog_api_address}
+
   @doc """
   Validates a map with string or atom keys that is intended to represent a
   CatalogApi address.

--- a/test/catalog_api/address_test.exs
+++ b/test/catalog_api/address_test.exs
@@ -27,6 +27,19 @@ defmodule CatalogApi.AddressTest do
                                postal_code: "44444",
                                country: "US"}
 
+  describe "cast/1" do
+    test "produces Item struct from json" do
+      assert %Address{} = Address.cast(@valid_address_params)
+    end
+
+    test "does not add invalid keys" do
+      json = Map.put(@valid_address_params, "bad_param", 123)
+      result = Address.cast(json)
+      refute Map.get(result, :bad_param)
+      refute Map.get(result, "bad_param")
+    end
+  end
+
   describe "validate_params" do
     test "returns :ok for valid address params" do
       assert :ok = Address.validate_params(@valid_address_params)

--- a/test/catalog_api_test.exs
+++ b/test/catalog_api_test.exs
@@ -1,9 +1,9 @@
 defmodule CatalogApiTest do
   use ExUnit.Case, async: false
-  doctest CatalogApi
 
   import Mock
 
+  alias CatalogApi.Address
   alias CatalogApi.CartItem
   alias CatalogApi.Category
   alias CatalogApi.Fault
@@ -182,9 +182,11 @@ defmodule CatalogApiTest do
     test "returns items in cart and the cart status for a successful response" do
       with_mock HTTPoison, [get: fn(_url) -> {:ok, Fixture.cart_view_success()} end] do
         response = CatalogApi.cart_view(123, 1)
-        assert {:ok, %{items: items, status: status}} = response
+        assert {:ok, %{items: items, address: address, status: status}} = response
 
         Enum.map(items, &(assert %CartItem{} = &1))
+
+        assert %Address{} = address
 
         assert status[:error] == ""
         assert status[:has_item_errors] == false
@@ -198,9 +200,11 @@ defmodule CatalogApiTest do
     test "returns items in cart if successful response but no address info" do
       with_mock HTTPoison, [get: fn(_url) -> {:ok, Fixture.cart_view_no_address_success()} end] do
         response = CatalogApi.cart_view(123, 1)
-        assert {:ok, %{items: items, status: status}} = response
+        assert {:ok, %{items: items, address: address, status: status}} = response
 
         Enum.map(items, &(assert %CartItem{} = &1))
+
+        assert %Address{} = address
 
         assert status[:error] == "The cart requires an address. "
         assert status[:has_item_errors] == false
@@ -214,7 +218,9 @@ defmodule CatalogApiTest do
     test "returns no items if successful response indicating an empty cart" do
       with_mock HTTPoison, [get: fn(_url) -> {:ok, Fixture.cart_view_empty_cart_success()} end] do
         response = CatalogApi.cart_view(123, 1)
-        assert {:ok, %{items: [], status: :cart_status_unavailable}} = response
+        assert {:ok, %{items: [], address: address, status: :cart_status_unavailable}} = response
+
+        assert %Address{} = address
       end
     end
 


### PR DESCRIPTION
Currently, the `CatalogApi.cart_view/2` function does not return addresses, even though the CatalogApi `cart_view` endpoint does return this data in the json. This adds that address in the event that it is present.