### PR TITLE
Properly format item categories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+.tool-versions

--- a/lib/catalog_api/item.ex
+++ b/lib/catalog_api/item.ex
@@ -39,7 +39,8 @@ defmodule CatalogApi.Item do
 
   def cast(item_json) when is_map(item_json) do
     item_json
-    |> filter_unknown_properties # To avoid dynamically creating atoms
+    # To avoid dynamically creating atoms
+    |> filter_unknown_properties
     |> Coercion.integer_fields_to_boolean(@boolean_fields, false)
     |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
     |> Enum.into(%{})
@@ -47,19 +48,21 @@ defmodule CatalogApi.Item do
     |> cast_categories
   end
 
-  def extract_items_from_json(
-    %{"view_item_response" =>
-      %{"view_item_result" =>
-        %{"item" => item}}}) do
+  def extract_items_from_json(%{
+        "view_item_response" => %{"view_item_result" => %{"item" => item}}
+      }) do
     {:ok, cast(item)}
   end
-  def extract_items_from_json(
-    %{"search_catalog_response" =>
-      %{"search_catalog_result" =>
-        %{"items" =>
-          %{"CatalogItem" => items}}}}) when is_list(items) do
+
+  def extract_items_from_json(%{
+        "search_catalog_response" => %{
+          "search_catalog_result" => %{"items" => %{"CatalogItem" => items}}
+        }
+      })
+      when is_list(items) do
     {:ok, Enum.map(items, &cast/1)}
   end
+
   def extract_items_from_json(_), do: {:error, :unparseable_catalog_api_items}
 
   defp filter_unknown_properties(map) do
@@ -68,9 +71,10 @@ defmodule CatalogApi.Item do
 
   defp to_struct(map), do: struct(Item, map)
 
-  defp cast_categories(%{categories: %{"integer" => categories}} = item) when is_list(categories) do
+  defp cast_categories(%{categories: %{"integer" => categories}} = item)
+       when is_list(categories) do
     %{item | categories: categories}
   end
-  defp cast_categories(item), do: %{item | categories: []}
 
+  defp cast_categories(item), do: %{item | categories: []}
 end

--- a/lib/catalog_api/item.ex
+++ b/lib/catalog_api/item.ex
@@ -10,7 +10,7 @@ defmodule CatalogApi.Item do
   defstruct brand: nil,
             catalog_item_id: nil,
             catalog_price: nil,
-            categories: %{}, # TODO Can default be more specific?
+            categories: [],
             currency: nil,
             description: nil,
             has_options: false,
@@ -44,6 +44,7 @@ defmodule CatalogApi.Item do
     |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
     |> Enum.into(%{})
     |> to_struct
+    |> cast_categories
   end
 
   def extract_items_from_json(
@@ -61,9 +62,15 @@ defmodule CatalogApi.Item do
   end
   def extract_items_from_json(_), do: {:error, :unparseable_catalog_api_items}
 
-  defp to_struct(map), do: struct(Item, map)
-
   defp filter_unknown_properties(map) do
     Enum.filter(map, fn {k, _v} -> k in @valid_fields end)
   end
+
+  defp to_struct(map), do: struct(Item, map)
+
+  defp cast_categories(%{categories: %{"integer" => categories}} = item) when is_list(categories) do
+    %{item | categories: categories}
+  end
+  defp cast_categories(item), do: %{item | categories: []}
+
 end

--- a/test/catalog_api/item_test.exs
+++ b/test/catalog_api/item_test.exs
@@ -3,7 +3,8 @@ defmodule CatalogApi.ItemTest do
   doctest CatalogApi.Item
   alias CatalogApi.Item
 
-  @base_item_json %{"brand" => "cat",
+  @base_item_json %{
+    "brand" => "cat",
     "catalog_item_id" => 123,
     "catalog_price" => "50.00",
     "categories" => %{},
@@ -21,7 +22,8 @@ defmodule CatalogApi.ItemTest do
     "rank" => 300,
     "retail_price" => "80.00",
     "shipping_estimate" => "10.00",
-    "tags" => %{"string" => []}}
+    "tags" => %{"string" => []}
+  }
 
   describe "cast/1" do
     test "produces an Item struct from json" do
@@ -41,8 +43,7 @@ defmodule CatalogApi.ItemTest do
 
     test "coerces to an error value if not coercable to boolean" do
       json = Map.put(@base_item_json, "has_options", 123)
-      assert %Item{has_options: {:error, :failed_boolean_coercion}}
-        = Item.cast(json)
+      assert %Item{has_options: {:error, :failed_boolean_coercion}} = Item.cast(json)
     end
 
     test "does not add invalid keys" do
@@ -72,8 +73,13 @@ defmodule CatalogApi.ItemTest do
 
     test "extracts items from the search_catalog response structure" do
       items = [@base_item_json, @base_item_json]
-      json = %{"search_catalog_response" => %{"search_catalog_result" =>
-        %{"items" => %{"CatalogItem" => items}}}}
+
+      json = %{
+        "search_catalog_response" => %{
+          "search_catalog_result" => %{"items" => %{"CatalogItem" => items}}
+        }
+      }
+
       assert {:ok, [%Item{}, %Item{}]} = Item.extract_items_from_json(json)
     end
 

--- a/test/catalog_api/item_test.exs
+++ b/test/catalog_api/item_test.exs
@@ -51,6 +51,17 @@ defmodule CatalogApi.ItemTest do
       refute Map.get(result, :bad_param)
       refute Map.get(result, "bad_param")
     end
+
+    test "casts categories to a list" do
+      item = Item.cast(@base_item_json)
+      assert %Item{} = item
+      assert item.categories == []
+
+      item_json = @base_item_json |> Map.put("categories", %{"integer" => [1, 2, 3]})
+      item = Item.cast(item_json)
+      assert %Item{} = item
+      assert item.categories == [1, 2, 3]
+    end
   end
 
   describe "extract_item_from_json/1" do


### PR DESCRIPTION
Rather than returning item categories in the format that catalog_api returns (e.g. `%{"integer" => [1, 2, 3]}`, we simply return the much more ergonomic value of `[1, 2, 3]`