### PR TITLE
Improve cart_empty/2

### DIFF
--- a/lib/catalog_api.ex
+++ b/lib/catalog_api.ex
@@ -273,6 +273,7 @@ defmodule CatalogApi do
        }) do
     {:ok, description}
   end
+
   defp extract_description(%{
          "cart_set_address_response" => %{
            "cart_set_address_result" => %{"description" => description}
@@ -280,6 +281,7 @@ defmodule CatalogApi do
        }) do
     {:ok, description}
   end
+
   defp extract_description(%{
          "cart_remove_item_response" => %{
            "cart_remove_item_result" => %{"description" => description}
@@ -295,6 +297,7 @@ defmodule CatalogApi do
        }) do
     {:ok, description}
   end
+
   defp extract_description(_), do: {:error, :unparseable_response_description}
 
   @doc """
@@ -343,6 +346,7 @@ defmodule CatalogApi do
   def cart_empty(socket_id, external_user_id) do
     params = %{socket_id: socket_id, external_user_id: external_user_id}
     url = Url.url_for("cart_empty", params)
+
     with {:ok, response} <- HTTPoison.get(url),
          :ok <- Error.validate_response_status(response),
          {:ok, json} <- parse_json(response.body),

--- a/test/catalog_api_test.exs
+++ b/test/catalog_api_test.exs
@@ -205,6 +205,30 @@ defmodule CatalogApiTest do
     end
   end
 
+  describe "cart_empty/2" do
+    test "returns a message if the response is successful" do
+      response_fixture = FixtureHelper.retrieve_json_response("cart_empty_success")
+      with_mock HTTPoison, get: fn _url -> {:ok, response_fixture} end do
+        response = CatalogApi.cart_empty(123, 500)
+        assert {:ok, %{description: _}} = response
+      end
+    end
+
+    test "returns an error tuple with a fault struct when CatalogApi responds with a fault" do
+      with_mock HTTPoison, get: fn _url -> {:ok, @fault_response} end do
+        response = CatalogApi.cart_empty(123, 500)
+        assert {:error, {:catalog_api_fault, %Fault{}}} = response
+      end
+    end
+
+    test "returns an error tuple when CatalogApi responds with an internal server error" do
+      with_mock HTTPoison, get: fn _url -> {:ok, @internal_error_response} end do
+        response = CatalogApi.cart_empty(123, 500)
+        assert {:error, {:bad_catalog_api_status, 500}} = response
+      end
+    end
+  end
+
   describe "cart_view/2" do
     test "returns items in cart and the cart status for a successful response" do
       with_mock HTTPoison, get: fn _url -> {:ok, Fixture.cart_view_success()} end do

--- a/test/fixtures/cart_empty_success.json
+++ b/test/fixtures/cart_empty_success.json
@@ -1,0 +1,13 @@
+{
+  "cart_empty_response": {
+    "cart_empty_result": {
+      "credentials": {
+        "checksum": "Q1flLAHJFELphzpiipG4K+2GpWg=",
+        "method": "cart_empty",
+        "uuid": "67fd2eed-4b89-4d7f-ae7b-6ff77eea3d1e",
+        "datetime": "2018-06-03T18:48:52.035789+00:00"
+      },
+      "description": "Cart emptied."
+    }
+  }
+}


### PR DESCRIPTION
`CatalogApi.cart_empty/2` now actually parses response codes as well as returns only relevant information (currently only the description).