### PR TITLE
Add explicit order struct for place_order return

### DIFF
--- a/lib/catalog_api.ex
+++ b/lib/catalog_api.ex
@@ -10,6 +10,7 @@ defmodule CatalogApi do
   alias CatalogApi.Error
   alias CatalogApi.Fault
   alias CatalogApi.Item
+  alias CatalogApi.Order
   alias CatalogApi.Url
 
   # TODO add param validation
@@ -548,7 +549,7 @@ defmodule CatalogApi do
   state of the cart to be,
   """
   @spec cart_order_place(integer(), integer(), Keyword.t()) ::
-          {:ok, map()}
+          {:ok, Order.t()}
           | {:error, :cart_not_found}
           | {:error, :no_shipping_address}
           | {:error, :stale_cart_version}
@@ -566,8 +567,9 @@ defmodule CatalogApi do
 
     with {:ok, response} <- HTTPoison.get(url),
          :ok <- Error.validate_response_status(response),
-         {:ok, json} <- parse_json(response.body) do
-      {:ok, json}
+         {:ok, json} <- parse_json(response.body),
+         {:ok, order} <- Order.extract_from_json(json) do
+      {:ok, order}
     else
       {:error, {:catalog_api_fault, %Fault{faultstring: "Cart not found."}}} ->
         {:error, :cart_not_found}

--- a/lib/catalog_api/order.ex
+++ b/lib/catalog_api/order.ex
@@ -1,0 +1,24 @@
+defmodule CatalogApi.Order do
+  @moduledoc """
+  Defines the `CatalogApi.Order` struct and associated functions for dealing
+  with orders in CatalogAPI responses.
+  """
+  defstruct order_id: nil
+
+  alias __MODULE__
+
+  @type t :: %Order{}
+
+  def cast(order_json) when is_map(order_json) do
+    %Order{
+      order_id: get_in(order_json, ["order_number"])
+    }
+  end
+
+  def extract_from_json(%{
+        "cart_order_place_response" => %{"cart_order_place_result" => order_json}
+      }) do
+    {:ok, cast(order_json)}
+  end
+  def extract_from_json(_), do: {:error, :unparseable_catalog_api_order}
+end

--- a/test/catalog_api/order_test.exs
+++ b/test/catalog_api/order_test.exs
@@ -1,0 +1,30 @@
+defmodule CatalogApi.OrderTest do
+  use ExUnit.Case, async: true
+
+  alias CatalogApi.Order
+
+  @base_order_json %{
+    "order_number" => "9563-02338-18554-0001"
+  }
+
+  describe "cast/1" do
+    test "produces an order from standard order_json" do
+      order = Order.cast(@base_order_json)
+      assert %Order{} = order
+      assert order.order_id == @base_order_json["order_number"]
+    end
+  end
+
+  describe "extract_order_from_json" do
+    test "extracts from cart_order_place response json" do
+      json = %{"cart_order_place_response" => %{"cart_order_place_result" => @base_order_json}}
+
+      assert {:ok, order} = Order.extract_from_json(json)
+      assert order.order_id == @base_order_json["order_number"]
+    end
+
+    test "returns error for unhandled json" do
+      assert {:error, :unparseable_catalog_api_order} == Order.extract_from_json(%{})
+    end
+  end
+end

--- a/test/catalog_api_test.exs
+++ b/test/catalog_api_test.exs
@@ -10,6 +10,7 @@ defmodule CatalogApiTest do
   alias CatalogApi.Fixture
   alias CatalogApi.FixtureHelper
   alias CatalogApi.Item
+  alias CatalogApi.Order
 
   @response_headers [
     {"Access-Control-Allow-Methods", "GET"},
@@ -294,7 +295,8 @@ defmodule CatalogApiTest do
     test "returns order information if order is successfully placed" do
       with_mock HTTPoison, get: fn _url -> {:ok, Fixture.cart_order_place_success()} end do
         response = CatalogApi.cart_order_place(1061, 1)
-        assert {:ok, _json} = response
+        assert {:ok, %Order{} = order} = response
+        refute is_nil(order.order_id)
       end
     end
 


### PR DESCRIPTION
Adds the `CatalogApi.Order` module which defines a struct for representing orders which are returned by CatalogApi.